### PR TITLE
Fix(dockerfile): add dependencies for grcpio

### DIFF
--- a/flask_login/Dockerfile
+++ b/flask_login/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
+RUN apk add build-base linux-headers
 COPY . /app
 WORKDIR /app
 RUN pip install -r requirements.txt 


### PR DESCRIPTION
Addresses #4 .

Adds a line to Dockerfile - installing dependencies for `grpcio`.

I tried a few things, but ultimately the fix came from [an issue on the grpc repo](https://github.com/grpc/grpc/issues/28166).

This PR also cheekily updates python from 3.7 -> 3.12. I'll happily remove this change if you'd like. 